### PR TITLE
fix royalroad url conversion for upgrade

### DIFF
--- a/src/routes/guides/upgrade/index.tsx
+++ b/src/routes/guides/upgrade/index.tsx
@@ -126,6 +126,9 @@ export default function Upgrade() {
         if (plugin.id === "boxnovel") {
           novelUrl = "novel/" + novelUrl + "/";
         }
+        if (plugin.id === "royalroad") {
+          novelUrl = "fiction/" + novelUrl + "/";
+        }
         migratedNovels.push({
           id: oldNovel.novelId,
           path: novelUrl.replace("//", "/"),


### PR DESCRIPTION
converted entries for royal road fail to show the relevant entry due to missing URL part. 

this code fix adds the required prefix